### PR TITLE
Cloud hosted README adjustments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -209,13 +209,13 @@ include::{common-includes}/os-tabs.adoc[]
 
 // static guide instructions:
 ifndef::cloud-hosted[]
-The services may take several minutes to become available. 
+The services take some time to become available.  
 You can access the application by making requests to the `query/systemLoad` endpoint by going to http://localhost:9080/query/systemLoad[http://localhost:9080/query/systemLoad^].
 endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-The services take some time to become available. 
+The services may take several minutes to become available.
 You can access the application by making requests to the **query/systemLoad** endpoint by running the following curl command:
 ```
 curl http://localhost:9080/query/systemLoad

--- a/README.adoc
+++ b/README.adoc
@@ -209,8 +209,8 @@ include::{common-includes}/os-tabs.adoc[]
 
 // static guide instructions:
 ifndef::cloud-hosted[]
-The services take some time to become available. 
-You can access the application by making requests to the `query/systemLoad` endpoint by going to http://localhost:9080/query/systemLoad[localhost:9080/query/systemLoad^].
+The services may take several minutes to become available. 
+You can access the application by making requests to the `query/systemLoad` endpoint by going to http://localhost:9080/query/systemLoad[http://localhost:9080/query/systemLoad^].
 endif::[]
 
 // cloud-hosted guide instructions:
@@ -299,6 +299,7 @@ Navigate to the `query` directory, then verify that the tests pass by using the 
 mvn verify
 ```
 
+The tests may take a few minutes to complete. 
 When the tests succeed, you see output similar to the following example:
 
 [source, role='no_copy']

--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,8 @@ Learn how to use MicroProfile Rest Client to invoke RESTful microservices asynch
 == What you'll learn
 
 You will learn how to build a MicroProfile Rest Client to access remote RESTful services using asynchronous method calls. 
-You'll update the template interface for a MicroProfile Rest Client, which maps to the remote service that you want to call, to use the `CompletionStage` return type. 
+You'll update the template interface for a MicroProfile Rest Client to use the `CompletionStage` return type. 
+The template interface maps to the remote service that you want to call. 
 A `CompletionStage` interface allows you to work with the result of your remote service call asynchronously.
 
 *What is asynchronous programming?*
@@ -210,12 +211,12 @@ include::{common-includes}/os-tabs.adoc[]
 // static guide instructions:
 ifndef::cloud-hosted[]
 The services take some time to become available.  
-You can access the application by making requests to the `query/systemLoad` endpoint by going to http://localhost:9080/query/systemLoad[http://localhost:9080/query/systemLoad^].
+You can access the application by making requests to the `query/systemLoad` endpoint by going to the http://localhost:9080/query/systemLoad[http://localhost:9080/query/systemLoad^] URL.
 endif::[]
 
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-The services may take several minutes to become available.
+The services might take several minutes to become available.
 You can access the application by making requests to the **query/systemLoad** endpoint by running the following curl command:
 ```
 curl http://localhost:9080/query/systemLoad
@@ -300,7 +301,7 @@ mvn verify
 ```
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
-The tests may take a few minutes to complete. 
+The tests might take a few minutes to complete. 
 endif::[]
 When the tests succeed, you see output similar to the following example:
 

--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ You will learn how to build a MicroProfile Rest Client to access remote RESTful 
 You'll update the template interface for a MicroProfile Rest Client, which maps to the remote service that you want to call, to use the `CompletionStage` return type. 
 A `CompletionStage` interface allows you to work with the result of your remote service call asynchronously.
 
-*What is asynchronous programming?* +
+*What is asynchronous programming?*
 Imagine asynchronous programming as a restaurant. 
 After you're seated, a waiter takes your order. 
 Then, you must wait a few minutes for your food to be prepared. 

--- a/README.adoc
+++ b/README.adoc
@@ -298,8 +298,10 @@ Navigate to the `query` directory, then verify that the tests pass by using the 
 ```
 mvn verify
 ```
-
+// cloud-hosted guide instructions:
+ifdef::cloud-hosted[]
 The tests may take a few minutes to complete. 
+endif::[]
 When the tests succeed, you see output similar to the following example:
 
 [source, role='no_copy']

--- a/README.adoc
+++ b/README.adoc
@@ -38,6 +38,7 @@ You'll update the template interface for a MicroProfile Rest Client, which maps 
 A `CompletionStage` interface allows you to work with the result of your remote service call asynchronously.
 
 *What is asynchronous programming?*
+
 Imagine asynchronous programming as a restaurant. 
 After you're seated, a waiter takes your order. 
 Then, you must wait a few minutes for your food to be prepared. 


### PR DESCRIPTION
Small formatting fix, the `+` for hard line breaks in `.adoc` appears as a literal `+` sign on the Cloud Hosted version of the guides.